### PR TITLE
Add openspecfun dependency, override OpenSpecFun_jll artifact

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,7 +21,7 @@ ${PYTHON} -c 'import pysr; pysr.install();'
 
 # Override OpenSpecFun_jll artifact with conda-forge binaries
 openspecfun_artifact_hash=`julia -e "using SymbolicRegression; print(basename(SymbolicRegression.CoreModule.OperatorsModule.SpecialFunctions.OpenSpecFun_jll.artifact_dir))"`
-echo "$openspecfun_artifact_hash = $PREFIX" >> "${FAKEDEPOT}/artifacts/Overrides.toml"
+echo "$openspecfun_artifact_hash = \"$PREFIX\"" >> "${FAKEDEPOT}/artifacts/Overrides.toml"
 rm -rf "${FAKEDEPOT}/artifacts/${openspecfun_artifact_hash}"
 
 # Copy packages, artifacts, environments, and conda dirs

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,6 +19,11 @@ export JULIA_PKG_PRECOMPILE_AUTO="0"
 mkdir -p "${FAKEDEPOT}"
 ${PYTHON} -c 'import pysr; pysr.install();'
 
+# Override OpenSpecFun_jll artifact with conda-forge binaries
+openspecfun_artifact_hash=`julia -e "using SymbolicRegression; print(basename(SymbolicRegression.CoreModule.OperatorsModule.SpecialFunctions.OpenSpecFun_jll.artifact_dir))"`
+echo "$openspecfun_artifact_hash = $PREFIX" >> "${FAKEDEPOT}/artifacts/Overrides.toml"
+rm -rf "${FAKEDEPOT}/artifacts/${openspecfun_artifact_hash}"
+
 # Copy packages, artifacts, environments, and conda dirs
 # into the real depot that we will package
 SRDEPOT="${PREFIX}/share/pysr/depot"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,8 @@ requirements:
     - pandas
     - sympy
     - scikit-learn
-    - openlibm <0.8.0
+    - openlibm
+    - openspecfun
   run:
     - python
     - pyjulia >=0.5.7
@@ -32,6 +33,7 @@ requirements:
     - sympy
     - scikit-learn
     - openlibm
+    - openspecfun
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 requirements:
   host:


### PR DESCRIPTION
@MilesCranmer, currently SymbolicRegression.jl depends on two binary artifacts from the Julia ecosystem:
1. [OpenSpecFun_jll](https://github.com/JuliaBinaryWrappers/OpenSpecFun_jll.jl)
Source: https://github.com/JuliaMath/openspecfun
2. [LLVMExtra_jll](https://github.com/JuliaBinaryWrappers/LLVMExtra_jll.jl)
Source: https://github.com/maleadt/LLVM.jl/tree/master/deps/LLVMExtra

This pull request replaces OpenSpecFun_jll with the openspecfun [conda-forge](https://github.com/conda-forge/openspecfun-feedstock) [package](https://anaconda.org/conda-forge/openspecfun). Thus, libopenspecfun.so is no longer packaged in the pysr conda-forge package. Rather, it is obtained via a new openspecfun dependency.

cc: @ngam 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
