### PR TITLE
Stop bleeding by pinning libstdcxx-ng <13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - click >=7.0.0
     - openlibm
     - openspecfun
-    - libstdcxx-ng <13
   run:
     - python
     - pyjulia >=0.6.0
@@ -40,6 +39,7 @@ requirements:
     - click >=7.0.0
     - openlibm
     - openspecfun
+  run_constrained:
     - libstdcxx-ng <13
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - click >=7.0.0
     - openlibm
     - openspecfun
+    - libstdcxx-ng <13
   run:
     - python
     - pyjulia >=0.6.0
@@ -39,6 +40,7 @@ requirements:
     - click >=7.0.0
     - openlibm
     - openspecfun
+    - libstdcxx-ng <13
 
 test:
   imports:


### PR DESCRIPTION
Seems like many people are having difficult using the conda version of PySR. Until we can fix the root cause I need to pin libstdcxx-ng to the last version which worked.