### PR TITLE
Update PySR upstream and maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @MilesCranmer
+* @MilesCranmer @adil-soubki @elizabethsztan

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/MilesCranmer/PySR/archive/v{{ version }}.tar.gz
+  - url: https://github.com/astroautomata/PySR/archive/v{{ version }}.tar.gz
     sha256: {{ sha256 }}
 
 build:
@@ -40,7 +40,7 @@ test:
     - python -m pysr test main
 
 about:
-  home: https://github.com/MilesCranmer/PySR
+  home: https://github.com/astroautomata/PySR
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
@@ -48,8 +48,10 @@ about:
   description: |
     PySR is a simple, fast, and parallelized symbolic regression package for Python and Julia, which makes use of an algorithm based on regularized evolution and simulated annealing.
   doc_url: https://ai.damtp.cam.ac.uk/pysr
-  dev_url: https://github.com/MilesCranmer/PySR
+  dev_url: https://github.com/astroautomata/PySR
 
 extra:
   recipe-maintainers:
     - MilesCranmer
+    - adil-soubki
+    - elizabethsztan


### PR DESCRIPTION
This updates the feedstock after PySR moved under the astroautomata organization.

Changes:
- point source/home/dev URLs at `astroautomata/PySR`
- add `adil-soubki` and `elizabethsztan` as recipe maintainers
- update existing feedstock CODEOWNERS to include the same maintainers

I verified that the new `astroautomata/PySR` v1.5.10 archive resolves and matches the existing SHA256.